### PR TITLE
refactor: Post Facade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework:spring-aspects'
 
 	// ======== Database ========
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/server/loop/domain/post/controller/PostController.java
+++ b/src/main/java/server/loop/domain/post/controller/PostController.java
@@ -18,6 +18,7 @@ import server.loop.domain.post.dto.post.res.PostDetailResponseDto;
 import server.loop.domain.post.dto.post.res.PostResponseDto;
 import server.loop.domain.post.dto.post.res.SliceResponseDto;
 import server.loop.domain.post.entity.Category;
+import server.loop.domain.post.service.PostFacade;
 import server.loop.domain.post.service.PostService;
 import server.loop.domain.user.entity.User;
 
@@ -35,6 +36,7 @@ import java.util.Map;
 public class PostController {
 
     private final PostService postService;
+    private final PostFacade postFacade;
 
     // 게시글 생성
     @Operation(summary = "게시글 생성", description = "새로운 게시글을 작성하고 이미지 파일을 업로드합니다.")
@@ -45,7 +47,7 @@ public class PostController {
             @AuthenticationPrincipal UserDetails userDetails) throws IOException {
 
         log.info("[CREATE_POST] dto={}, category={}, principal={}", requestDto, requestDto.getCategory(), userDetails.getUsername());
-        Long postId = postService.createPost(requestDto, images, userDetails.getUsername());
+        Long postId = postFacade.createPost(requestDto, images, userDetails.getUsername());
         return ResponseEntity.ok("게시글이 성공적으로 생성되었습니다. ID: " + postId);
     }
 
@@ -72,7 +74,7 @@ public class PostController {
             @AuthenticationPrincipal UserDetails userDetails
     ) throws AccessDeniedException, IOException {
         log.info("[UPDATE_POST] postId={}, principal={}", postId, userDetails.getUsername());
-        postService.updatePost(postId, requestDto, images, userDetails.getUsername());
+        postFacade.updatePost(postId, requestDto, images, userDetails.getUsername());
         return ResponseEntity.ok("게시글이 성공적으로 수정되었습니다. ID: " + postId);
     }
 
@@ -83,7 +85,7 @@ public class PostController {
     public ResponseEntity<Map<String, Object>> deletePost(@PathVariable Long postId,
                                                           @AuthenticationPrincipal UserDetails userDetails) throws AccessDeniedException {
         log.info("[DELETE_POST] postId={}, principal={}", postId, userDetails.getUsername());
-        postService.deletePost(postId, userDetails.getUsername());
+        postFacade.deletePost(postId, userDetails.getUsername());
 
         Map<String, Object> response = new HashMap<>();
         response.put("message", "게시글이 성공적으로 삭제되었습니다.");

--- a/src/main/java/server/loop/domain/post/dto/post/req/PostUpdateRequestDto.java
+++ b/src/main/java/server/loop/domain/post/dto/post/req/PostUpdateRequestDto.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import server.loop.domain.post.entity.Category;
 
+import java.util.List;
+
 @Getter
 @Setter
 @Schema(description = "게시글 수정 요청")
@@ -18,4 +20,7 @@ public class PostUpdateRequestDto {
 
     @Schema(description = "수정할 카테고리", example = "USED")
     private Category category;
+
+    @Schema(description = "삭제할 사진 List", example = "String List")
+    private List<Long> deleteImageIds;
 }

--- a/src/main/java/server/loop/domain/post/service/PostFacade.java
+++ b/src/main/java/server/loop/domain/post/service/PostFacade.java
@@ -1,0 +1,94 @@
+package server.loop.domain.post.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import server.loop.domain.post.dto.post.req.PostCreateRequestDto;
+import server.loop.domain.post.dto.post.req.PostUpdateRequestDto;
+import server.loop.global.config.s3.S3UploadService;
+
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostFacade {
+    private final PostService postService;
+    private final S3UploadService s3UploadService;
+
+    // 게시글 생성 Facade
+    public Long createPost(PostCreateRequestDto requestDto, List<MultipartFile> images, String email) throws IOException {
+        List<String> uploadedUrls = new ArrayList<>();
+        try{
+            if(images != null && !images.isEmpty()){
+                for(MultipartFile image : images){
+                    uploadedUrls.add(s3UploadService.uploadFile(image, "post-images"));                }
+            }
+            return postService.createPostInTransaction(requestDto, uploadedUrls, email);
+        } catch (Exception e){
+            log.error("게시글 생성 실패. 업로드된 이미지 롤백 수행. error={}", e.getMessage());
+            deleteUploadedImages(uploadedUrls);
+            throw e;
+
+        }
+    }
+
+    // 2. 게시글 수정 Facade
+    public Long updatePost(Long postId, PostUpdateRequestDto requestDto, List<MultipartFile> newImages, String email) throws IOException {
+
+        List<String> newUploadedUrls = new ArrayList<>();
+
+        try {
+            // 1) 새 이미지 S3 업로드
+            if (newImages != null && !newImages.isEmpty()) {
+                for (MultipartFile image : newImages) {
+                    newUploadedUrls.add(s3UploadService.uploadFile(image, "post-images"));
+                }
+            }
+
+            // 2) DB 업데이트 진행
+            // requestDto.getDeleteImageIds()로 DTO에서 꺼내서 넘깁니다.
+            List<String> urlsToDelete = postService.updatePostInTransaction(
+                    postId,
+                    requestDto,
+                    newUploadedUrls,
+                    requestDto.getDeleteImageIds(), // [여기 수정됨] DTO에서 꺼냄
+                    email
+            );
+
+            // 3) 구 이미지 S3 삭제
+            deleteUploadedImages(urlsToDelete);
+
+            return postId;
+
+        } catch (Exception e) {
+            log.error("게시글 수정 실패. 업로드된 새 이미지 롤백 수행.");
+            deleteUploadedImages(newUploadedUrls);
+            throw e;
+        }
+    }
+
+    // 3. 게시글 삭제 Facade
+    public void deletePost(Long postId, String email) throws AccessDeniedException {
+        // DB에서 먼저 삭제하고, 삭제된 이미지 URL 목록을 받아옴
+        List<String> urlsToDelete = postService.deletePostInTransaction(postId, email);
+
+        // S3 파일 삭제
+        deleteUploadedImages(urlsToDelete);
+    }
+
+    private void deleteUploadedImages(List<String> urls) {
+        if (urls == null) return;
+        for (String url : urls) {
+            try {
+                s3UploadService.deleteImageFromS3(url);
+            } catch (Exception e) {
+                log.error("S3 이미지 삭제 실패 (고아 객체 발생 가능성): {}", url, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
**S3 이미지 업로드와 DB 트랜잭션 분리를 통한 성능 최적화 및 Retry 로직 적용을 통한 안정성 강화**

기존의 강결합된 서비스 로직을 개선하여 외부 I/O(S3) 지연이 DB 커넥션 풀에 영향을 주지 않도록 **Facade 패턴**을 도입하고, **Spring Retry**를 적용하여 네트워크 불안정성에 대비했습니다.

## Background
1. **DB 커넥션 고갈 위험 (Connection Pool Starvation)**
   - 기존 `PostService`는 클래스 레벨 `@Transactional`로 인해 S3 업로드 시간만큼 DB 커넥션을 점유하고 있었습니다.
   - S3 응답 지연 시, 전체 서버의 DB 커넥션이 고갈되어 장애(Hang)로 이어질 수 있는 구조였습니다.

2. **네트워크 불안정성 대응 부재**
   - AWS SDK의 일시적인 네트워크 오류(`SdkClientException`)에도 즉시 예외가 발생하여 사용자 경험을 저해했습니다.

3. **예외 처리 및 롤백 전략 미흡**
   - S3에는 파일이 올라갔으나 DB 저장이 실패할 경우, '고아 파일(Orphan File)'이 남는 문제가 있었습니다.
   - `S3UploadService` 내부의 `try-catch`가 예외를 삼켜버려 상위에서 적절한 처리가 불가능했습니다.

## Changes
### 1. Architecture Refactoring (Facade Pattern 도입)
- **`PostFacade` 추가**
  - 트랜잭션이 **필요 없는** 구간(S3 업로드)과 **필요한** 구간(DB 저장)을 분리하여 조율(Orchestration)합니다.
  - `@Transactional` 어노테이션을 사용하지 않으며, 수동 롤백(보상 트랜잭션) 로직을 담당합니다.
- **`PostService` 경량화**
  - `MultipartFile` 및 S3 의존성을 모두 제거했습니다.
  - 오직 순수 DB 작업(`save`, `update` 등)만 수행하며, 확실한 트랜잭션 범위를 보장합니다.

### 2. S3UploadService 개선 (Spring Retry 적용)
- **Retry 정책 적용:** `IOException`, `SdkClientException` 등 네트워크/IO 문제 발생 시 최대 3회 재시도합니다.
- **Smart Retry:** `S3Exception`(400, 403, 404 등 비즈니스 에러)은 재시도 대상에서 제외(`exclude`)하여 불필요한 리소스 낭비를 막았습니다.
- **Bug Fix:** AOP(`@Retryable`) 동작을 방해하던 내부 `try-catch` 블록을 제거하고 예외를 전파하도록 수정했습니다.
- **Recover:** 재시도 최종 실패 시 로그를 남기는 `@Recover` 메서드를 추가했습니다.

### 3. API & DTO Update
- **`PostUpdateRequestDto`:** 게시글 수정 시 삭제할 이미지 ID 목록을 받기 위해 `List<Long> deleteImageIds` 필드를 추가했습니다.
- **`PostController`:** Service 대신 Facade를 호출하도록 의존성을 변경했습니다.

## Impact
- **Performance:** S3 업로드 속도와 관계없이 DB 커넥션 점유 시간이 획기적으로 단축(수 ms 단위)되어, 트래픽 급증 시에도 DB 부하를 최소화합니다.
- **Stability:** 일시적인 네트워크 깜빡임(Glitch) 발생 시 재시도를 통해 정상 처리될 확률이 높아집니다.
- **Consistency:** "S3 성공 -> DB 실패" 시나리오 발생 시, Facade의 `catch` 블록이 업로드된 파일을 즉시 삭제하여 데이터 정합성을 유지합니다.

## Notes
- **Review Point:** `S3UploadService`의 `exclude = {S3Exception.class}` 설정이 AWS SDK v2의 예외 계층 구조와 일치하는지 확인 부탁드립니다.
- **Policy Check:** 현재 게시글 삭제 시 DB는 Soft Delete(`deleted_at`), S3 이미지는 Hard Delete(완전 삭제)로 동작합니다. 추후 복구 기능을 고려한다면 이미지 삭제 정책에 대한 논의가 필요합니다.