### PR TITLE
fix: harden auth/exception handling and enforce soft-delete access guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 /application.yml
+k6-script.js

--- a/src/main/java/server/loop/LoopApplication.java
+++ b/src/main/java/server/loop/LoopApplication.java
@@ -3,11 +3,13 @@ package server.loop;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableAsync
+@EnableRetry
 public class LoopApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/server/loop/domain/ad/controller/AdController.java
+++ b/src/main/java/server/loop/domain/ad/controller/AdController.java
@@ -34,7 +34,7 @@ public class AdController {
             @RequestPart("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestPart("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @RequestPart("active") boolean active
-    ) throws IOException {
+    ) {
         log.info("[CreateAd] linkUrl={}, start={}, end={}, active={}", linkUrl, startDate, endDate, active);
         Ad savedAd = adService.createAd(image, linkUrl, startDate, endDate, active);
         return ResponseEntity.ok(savedAd);

--- a/src/main/java/server/loop/domain/ad/service/AdService.java
+++ b/src/main/java/server/loop/domain/ad/service/AdService.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import server.loop.domain.ad.entity.Ad;
 import server.loop.domain.ad.entity.repository.AdRepository;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 import server.loop.global.config.s3.S3UploadService;
 
 import java.io.IOException;
@@ -24,11 +26,14 @@ public class AdService {
         LocalDate today = LocalDate.now();
         return adRepository.findActiveAds(today);
     }
-    private final S3UploadService s3Uploader;
-
-    public Ad createAd(MultipartFile image, String linkUrl, LocalDate startDate, LocalDate endDate, boolean active) throws IOException {
+    public Ad createAd(MultipartFile image, String linkUrl, LocalDate startDate, LocalDate endDate, boolean active) {
         // 1. S3 업로드
-        String imageUrl = s3UploadService.uploadFile(image, "ads");
+        String imageUrl;
+        try {
+            imageUrl = s3UploadService.uploadFile(image, "ads");
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.IO_EXCEPTION_ON_IMAGE_UPLOAD, e.getMessage());
+        }
 
         // 2. 광고 엔티티 생성 및 저장
         Ad ad = Ad.builder()

--- a/src/main/java/server/loop/domain/auth/service/TokenService.java
+++ b/src/main/java/server/loop/domain/auth/service/TokenService.java
@@ -8,6 +8,9 @@ import server.loop.domain.auth.entity.RefreshToken;
 import server.loop.domain.auth.entity.repo.RefreshTokenRepository;
 import server.loop.global.security.JwtTokenProvider;
 
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
+
 @Service
 @RequiredArgsConstructor
 public class TokenService {
@@ -18,11 +21,11 @@ public class TokenService {
     @Transactional
     public TokenDto reissueTokens(String refreshToken) {
         if (!jwtTokenProvider.validateToken(refreshToken)) {
-            throw new IllegalArgumentException("유효하지 않은 Refresh Token 입니다.");
+            throw new CustomException(ErrorCode.INVALID_TOKEN, "유효하지 않은 Refresh Token 입니다.");
         }
 
         RefreshToken foundRefreshToken = refreshTokenRepository.findByToken(refreshToken)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Refresh Token 입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN, "존재하지 않는 Refresh Token 입니다."));
 
         String newAccessToken = jwtTokenProvider.createAccessToken(foundRefreshToken.getUser().getEmail());
 

--- a/src/main/java/server/loop/domain/chat/controller/ChatController.java
+++ b/src/main/java/server/loop/domain/chat/controller/ChatController.java
@@ -87,8 +87,9 @@ public class ChatController {
             @PathVariable String roomId,
             @RequestParam(defaultValue = "50") int size,
             @RequestParam(required = false) Long beforeId,
+            @RequestParam(required = false) Long afterId,
             @AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.ok(chatService.getMessages(userDetails, roomId, size, beforeId));
+        return ResponseEntity.ok(chatService.getMessages(userDetails, roomId, size, beforeId, afterId));
     }
 
     @GetMapping("/rooms/{roomId}")

--- a/src/main/java/server/loop/domain/chat/entity/repository/ChatMessageRepositoryCustom.java
+++ b/src/main/java/server/loop/domain/chat/entity/repository/ChatMessageRepositoryCustom.java
@@ -6,6 +6,6 @@ import server.loop.domain.chat.entity.ChatMessage;
 import java.util.List;
 
 public interface ChatMessageRepositoryCustom {
-    // 채팅방 메시지 페이징 조회 (커서 기반)
-    List<ChatMessage> findMessages(String roomId, Long lastMessageId, Pageable pageable);
+    // beforeMessageId: 과거 메시지 조회(무한 스크롤), afterMessageId: 누락 메시지 동기화
+    List<ChatMessage> findMessages(String roomId, Long beforeMessageId, Long afterMessageId, Pageable pageable);
 }

--- a/src/main/java/server/loop/domain/chat/event/ChatMessageEventListener.java
+++ b/src/main/java/server/loop/domain/chat/event/ChatMessageEventListener.java
@@ -1,0 +1,27 @@
+package server.loop.domain.chat.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageEventListener {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleChatMessageSavedEvent(ChatMessageSavedEvent event) {
+        try {
+            messagingTemplate.convertAndSend("/topic/chat." + event.getRoomId(), event.getPayload());
+        } catch (Exception e) {
+            log.error("[ChatMessageDeliveryFail] roomId={}, error={}", event.getRoomId(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/server/loop/domain/chat/event/ChatMessageSavedEvent.java
+++ b/src/main/java/server/loop/domain/chat/event/ChatMessageSavedEvent.java
@@ -1,0 +1,13 @@
+package server.loop.domain.chat.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import server.loop.domain.chat.dto.res.ChatMessageResponse;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatMessageSavedEvent {
+
+    private final String roomId;
+    private final ChatMessageResponse payload;
+}

--- a/src/main/java/server/loop/domain/chat/service/ChatService.java
+++ b/src/main/java/server/loop/domain/chat/service/ChatService.java
@@ -25,6 +25,8 @@ import server.loop.domain.post.entity.Post;
 import server.loop.domain.post.entity.repository.PostRepository;
 import server.loop.domain.user.entity.User;
 import server.loop.domain.user.entity.repository.UserRepository;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 
 import java.util.List;
 import java.util.UUID;
@@ -71,7 +73,7 @@ public class ChatService {
         log.info("[JoinChatRoom] roomId={}, user={}", roomId, user.getEmail());
 
         if (!"PUBLIC".equals(room.getVisibility())) {
-            throw new IllegalStateException("공개방이 아닙니다. 초대/승인이 필요합니다.");
+            throw new CustomException(ErrorCode.FORBIDDEN_USER, "공개방이 아닙니다. 초대/승인이 필요합니다.");
         }
         if (!memberRepository.existsByRoomAndUser(room, user)) {
             memberRepository.save(ChatRoomMember.builder()
@@ -123,17 +125,17 @@ public class ChatService {
         User me = currentUser(userDetails);
 
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         if (post.getCategory() != Category.USED) {
-            throw new IllegalStateException("중고 거래 게시글에서만 1:1 채팅이 가능합니다.");
+            throw new CustomException(ErrorCode.CONFLICT, "중고 거래 게시글에서만 1:1 채팅이 가능합니다.");
         }
 
         User seller = post.getAuthor();
         log.info("[StartPrivateChat] buyer={}, seller={}, postId={}", me.getEmail(), seller.getEmail(), postId);
 
         if (me.getId().equals(seller.getId())) {
-            throw new IllegalArgumentException("자신의 게시글과는 채팅할 수 없습니다.");
+            throw new CustomException(ErrorCode.CONFLICT, "자신의 게시글과는 채팅할 수 없습니다.");
         }
 
         return memberRepository.findByRoom_PostAndUser(post, me)
@@ -170,7 +172,7 @@ public class ChatService {
         ChatRoom room = getRoomOrThrow(req.getRoomId());
 
         if (!memberRepository.existsByRoomAndUser(room, sender)) {
-            throw new IllegalStateException("해당 채팅방의 멤버가 아닙니다.");
+            throw new CustomException(ErrorCode.FORBIDDEN_USER, "해당 채팅방의 멤버가 아닙니다.");
         }
 
         ChatMessage saved = messageRepository.save(ChatMessage.builder()
@@ -192,7 +194,7 @@ public class ChatService {
         ChatRoom room = getRoomOrThrow(roomId);
 
         if (!memberRepository.existsByRoomAndUser(room, me)) {
-            throw new IllegalStateException("해당 채팅방의 멤버가 아닙니다.");
+            throw new CustomException(ErrorCode.FORBIDDEN_USER, "해당 채팅방의 멤버가 아닙니다.");
         }
 
         PageRequest pr = PageRequest.of(0, Math.min(size, 100));
@@ -216,11 +218,11 @@ public class ChatService {
 
     private User currentUser(UserDetails userDetails) {
         if (userDetails == null || userDetails.getUsername() == null) {
-            throw new IllegalStateException("인증 정보가 없습니다.");
+            throw new CustomException(ErrorCode.UNAUTHORIZED_USER, "인증 정보가 없습니다.");
         }
         String email = userDetails.getUsername(); 
         return userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다. email=" + email));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다. email=" + email));
     }
 
     private User currentUserOrNull(UserDetails userDetails) {
@@ -231,7 +233,7 @@ public class ChatService {
 
     private ChatRoom getRoomOrThrow(String roomId) {
         return chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다. roomId=" + roomId));
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND, "존재하지 않는 채팅방입니다. roomId=" + roomId));
     }
 
     private String normalizeVisibility(String v) {

--- a/src/main/java/server/loop/domain/chat/service/ChatService.java
+++ b/src/main/java/server/loop/domain/chat/service/ChatService.java
@@ -125,7 +125,7 @@ public class ChatService {
     public ChatRoomResponse startPrivateChat(UserDetails userDetails, Long postId) {
         User me = currentUser(userDetails);
 
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         if (post.getCategory() != Category.USED) {

--- a/src/main/java/server/loop/domain/chat/service/ChatService.java
+++ b/src/main/java/server/loop/domain/chat/service/ChatService.java
@@ -188,16 +188,19 @@ public class ChatService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatMessageResponse> getMessages(UserDetails userDetails, String roomId, int size, Long beforeId) {
+    public List<ChatMessageResponse> getMessages(UserDetails userDetails, String roomId, int size, Long beforeId, Long afterId) {
         User me = currentUser(userDetails);
         ChatRoom room = getRoomOrThrow(roomId);
 
         if (!memberRepository.existsByRoomAndUser(room, me)) {
             throw new IllegalStateException("해당 채팅방의 멤버가 아닙니다.");
         }
+        if (beforeId != null && afterId != null) {
+            throw new IllegalArgumentException("beforeId와 afterId는 동시에 사용할 수 없습니다.");
+        }
 
         PageRequest pr = PageRequest.of(0, Math.min(size, 100));
-        List<ChatMessage> list = messageRepository.findMessages(roomId, beforeId, pr);
+        List<ChatMessage> list = messageRepository.findMessages(roomId, beforeId, afterId, pr);
 
         return list.stream().map(this::toMessageResponse).toList();
     }

--- a/src/main/java/server/loop/domain/notification/controller/NotificationController.java
+++ b/src/main/java/server/loop/domain/notification/controller/NotificationController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.*;
 import server.loop.domain.notification.dto.res.NotificationResponseDto;
 import server.loop.domain.notification.service.NotificationService;
 import server.loop.domain.user.entity.repository.UserRepository;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 
 @Slf4j
 @RestController
@@ -44,7 +46,7 @@ public class NotificationController {
         log.info("[GetNotifications] user={}", userDetails.getUsername());
 
         var user = userRepository.findByEmail(userDetails.getUsername())
-                .orElseThrow();
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
         Page<NotificationResponseDto> notifications = notificationService.getUserNotifications(user, pageable);
         return ResponseEntity.ok(notifications);
@@ -59,7 +61,7 @@ public class NotificationController {
     ) {
         log.info("[ReadNotification] id={}, user={}", id, userDetails.getUsername());
         var user = userRepository.findByEmail(userDetails.getUsername())
-                .orElseThrow();
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
         notificationService.markAsRead(id, user);
         return ResponseEntity.ok().build();
     }
@@ -72,7 +74,7 @@ public class NotificationController {
     ) {
         log.info("[DeleteAllNotifications] user={}", userDetails.getUsername());
         var user = userRepository.findByEmail(userDetails.getUsername())
-                .orElseThrow();
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
         notificationService.deleteAllByUser(user);
         return ResponseEntity.ok().build();
     }
@@ -85,7 +87,7 @@ public class NotificationController {
     ) {
         log.info("[ReadAllNotifications] user={}", userDetails.getUsername());
         var user = userRepository.findByEmail(userDetails.getUsername())
-                .orElseThrow();
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
         notificationService.markAllAsRead(user);
         return ResponseEntity.ok().build();
     }
@@ -97,7 +99,7 @@ public class NotificationController {
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails
     ) {
         var user = userRepository.findByEmail(userDetails.getUsername())
-                .orElseThrow();
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
         int count = notificationService.countUnreadNotifications(user);
         return ResponseEntity.ok(count);
     }

--- a/src/main/java/server/loop/domain/notification/controller/NotificationController.java
+++ b/src/main/java/server/loop/domain/notification/controller/NotificationController.java
@@ -18,6 +18,8 @@ import server.loop.domain.notification.dto.res.NotificationResponseDto;
 import server.loop.domain.notification.service.NotificationService;
 import server.loop.domain.user.entity.repository.UserRepository;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/notifications")
@@ -48,6 +50,21 @@ public class NotificationController {
 
         Page<NotificationResponseDto> notifications = notificationService.getUserNotifications(user, pageable);
         return ResponseEntity.ok(notifications);
+    }
+
+    @Operation(summary = "누락 알림 동기화", description = "특정 알림 ID 이후 생성된 알림만 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "누락 알림 동기화 성공")
+    @GetMapping("/sync")
+    public ResponseEntity<List<NotificationResponseDto>> syncNotifications(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+            @Parameter(description = "마지막으로 수신한 알림 ID", example = "120")
+            @RequestParam Long afterId,
+            @Parameter(description = "조회 크기(최대 100)", example = "50")
+            @RequestParam(defaultValue = "50") int size
+    ) {
+        var user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow();
+        return ResponseEntity.ok(notificationService.getNotificationsSince(user, afterId, size));
     }
 
     @Operation(summary = "단일 알림 읽음 처리", description = "알림 ID를 기반으로 해당 알림을 읽음 처리합니다.")

--- a/src/main/java/server/loop/domain/notification/entity/repository/NotificationRepository.java
+++ b/src/main/java/server/loop/domain/notification/entity/repository/NotificationRepository.java
@@ -14,6 +14,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @EntityGraph(attributePaths = {"sender"})
     Page<Notification> findByReceiverOrderByCreatedAtDesc(User receiver, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"sender"})
+    List<Notification> findByReceiverAndIdGreaterThanOrderByIdAsc(User receiver, Long id, Pageable pageable);
+
     void deleteByReceiver(User receiver);
     List<Notification> findByReceiver(User receiver);
 

--- a/src/main/java/server/loop/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/server/loop/domain/notification/event/NotificationEventListener.java
@@ -2,7 +2,6 @@ package server.loop.domain.notification.event;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;

--- a/src/main/java/server/loop/domain/notification/event/NotificationRealtimeEventListener.java
+++ b/src/main/java/server/loop/domain/notification/event/NotificationRealtimeEventListener.java
@@ -1,0 +1,36 @@
+package server.loop.domain.notification.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationRealtimeEventListener {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleNotificationSavedEvent(NotificationSavedEvent event) {
+        try {
+            messagingTemplate.convertAndSendToUser(
+                    event.getReceiverEmail(),
+                    "/queue/notifications",
+                    event.getPayload()
+            );
+        } catch (Exception e) {
+            log.error(
+                    "[NotificationDeliveryFail] receiver={}, error={}",
+                    event.getReceiverEmail(),
+                    e.getMessage(),
+                    e
+            );
+        }
+    }
+}

--- a/src/main/java/server/loop/domain/notification/event/NotificationSavedEvent.java
+++ b/src/main/java/server/loop/domain/notification/event/NotificationSavedEvent.java
@@ -1,0 +1,13 @@
+package server.loop.domain.notification.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import server.loop.domain.notification.dto.res.NotificationResponseDto;
+
+@Getter
+@RequiredArgsConstructor
+public class NotificationSavedEvent {
+
+    private final String receiverEmail;
+    private final NotificationResponseDto payload;
+}

--- a/src/main/java/server/loop/domain/notification/service/NotificationService.java
+++ b/src/main/java/server/loop/domain/notification/service/NotificationService.java
@@ -2,14 +2,15 @@ package server.loop.domain.notification.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.loop.domain.notification.dto.res.NotificationResponseDto;
 import server.loop.domain.notification.entity.Notification;
 import server.loop.domain.notification.entity.repository.NotificationRepository;
+import server.loop.domain.notification.event.NotificationSavedEvent;
 import server.loop.domain.post.entity.Comment;
 import server.loop.domain.post.entity.Post;
 import server.loop.domain.user.entity.User;
@@ -22,7 +23,7 @@ import java.util.List;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
-    private final SimpMessagingTemplate messagingTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void send(User sender, User receiver, Post post, Comment comment, String postTitle, String message) {
@@ -42,7 +43,7 @@ public class NotificationService {
         notificationRepository.save(notification);
 
         NotificationResponseDto dto = NotificationResponseDto.from(notification);
-        messagingTemplate.convertAndSendToUser(receiver.getEmail(), "/queue/notifications", dto);
+        eventPublisher.publishEvent(new NotificationSavedEvent(receiver.getEmail(), dto));
     }
 
 

--- a/src/main/java/server/loop/domain/notification/service/NotificationService.java
+++ b/src/main/java/server/loop/domain/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,6 +52,19 @@ public class NotificationService {
     public Page<NotificationResponseDto> getUserNotifications(User receiver, Pageable pageable) {
         return notificationRepository.findByReceiverOrderByCreatedAtDesc(receiver, pageable)
                 .map(NotificationResponseDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponseDto> getNotificationsSince(User receiver, Long afterId, int size) {
+        if (afterId == null) {
+            return List.of();
+        }
+        int boundedSize = Math.min(Math.max(size, 1), 100);
+        return notificationRepository
+                .findByReceiverAndIdGreaterThanOrderByIdAsc(receiver, afterId, PageRequest.of(0, boundedSize))
+                .stream()
+                .map(NotificationResponseDto::from)
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/server/loop/domain/notification/service/NotificationService.java
+++ b/src/main/java/server/loop/domain/notification/service/NotificationService.java
@@ -13,6 +13,8 @@ import server.loop.domain.notification.entity.repository.NotificationRepository;
 import server.loop.domain.post.entity.Comment;
 import server.loop.domain.post.entity.Post;
 import server.loop.domain.user.entity.User;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 
 import java.util.List;
 
@@ -55,9 +57,9 @@ public class NotificationService {
     @Transactional
     public void markAsRead(Long id, User user) {
         Notification notification = notificationRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("알림 없음"));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
         if (!notification.getReceiver().getId().equals(user.getId())) {
-            throw new SecurityException("본인의 알림만 열람 가능");
+            throw new CustomException(ErrorCode.FORBIDDEN_USER, "본인의 알림만 열람 가능");
         }
         notification.markAsRead();
     }

--- a/src/main/java/server/loop/domain/post/controller/CommentController.java
+++ b/src/main/java/server/loop/domain/post/controller/CommentController.java
@@ -47,7 +47,7 @@ public class CommentController {
     @PutMapping(value = "/comments/{commentId}", produces = "application/json") // 수정
     public ResponseEntity<List<CommentResponseDto>> updateComment(@PathVariable Long commentId,
                                                                   @RequestBody CommentUpdateRequestDto requestDto,
-                                                                  @AuthenticationPrincipal UserDetails userDetails) throws AccessDeniedException {
+                                                                  @AuthenticationPrincipal UserDetails userDetails) {
         log.info("[UpdateComment] commentId={}, user={}", commentId, userDetails.getUsername());
         Long postId = commentService.updateComment(commentId, requestDto, userDetails.getUsername());
         List<CommentResponseDto> updatedComments = commentService.getCommentsByPost(postId);
@@ -57,7 +57,7 @@ public class CommentController {
     @Operation(summary = "댓글 삭제", description = "작성자 본인의 댓글을 삭제 후 최신 댓글 리스트를 반환합니다.")
     @DeleteMapping(value = "/comments/{commentId}", produces = "application/json") // 수정
     public ResponseEntity<List<CommentResponseDto>> deleteComment(@PathVariable Long commentId,
-                                                                  @AuthenticationPrincipal UserDetails userDetails) throws AccessDeniedException {
+                                                                  @AuthenticationPrincipal UserDetails userDetails) {
         log.info("[DeleteComment] commentId={}, user={}", commentId, userDetails.getUsername());
         Long postId = commentService.deleteComment(commentId, userDetails.getUsername());
         List<CommentResponseDto> updatedComments = commentService.getCommentsByPost(postId);

--- a/src/main/java/server/loop/domain/post/controller/PostController.java
+++ b/src/main/java/server/loop/domain/post/controller/PostController.java
@@ -44,7 +44,7 @@ public class PostController {
     public ResponseEntity<String> createPost(
             @RequestPart("requestDto") PostCreateRequestDto requestDto, // 2. JSON 데이터 부분
             @RequestPart(value = "images", required = false) List<MultipartFile> images, // 3. 파일 부분
-            @AuthenticationPrincipal UserDetails userDetails) throws IOException {
+            @AuthenticationPrincipal UserDetails userDetails) {
 
         log.info("[CREATE_POST] dto={}, category={}, principal={}", requestDto, requestDto.getCategory(), userDetails.getUsername());
         Long postId = postFacade.createPost(requestDto, images, userDetails.getUsername());
@@ -72,7 +72,7 @@ public class PostController {
             @RequestPart("requestDto") PostUpdateRequestDto requestDto,
             @RequestPart(value = "images", required = false) List<MultipartFile> images,
             @AuthenticationPrincipal UserDetails userDetails
-    ) throws AccessDeniedException, IOException {
+    ) {
         log.info("[UPDATE_POST] postId={}, principal={}", postId, userDetails.getUsername());
         postFacade.updatePost(postId, requestDto, images, userDetails.getUsername());
         return ResponseEntity.ok("게시글이 성공적으로 수정되었습니다. ID: " + postId);
@@ -83,7 +83,7 @@ public class PostController {
     @Operation(summary = "게시글 삭제", description = "작성자 본인의 게시글을 삭제합니다.")
     @DeleteMapping("/{postId}")
     public ResponseEntity<Map<String, Object>> deletePost(@PathVariable Long postId,
-                                                          @AuthenticationPrincipal UserDetails userDetails) throws AccessDeniedException {
+                                                          @AuthenticationPrincipal UserDetails userDetails) {
         log.info("[DELETE_POST] postId={}, principal={}", postId, userDetails.getUsername());
         postFacade.deletePost(postId, userDetails.getUsername());
 

--- a/src/main/java/server/loop/domain/post/entity/repository/CommentRepository.java
+++ b/src/main/java/server/loop/domain/post/entity/repository/CommentRepository.java
@@ -3,5 +3,8 @@ package server.loop.domain.post.entity.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.loop.domain.post.entity.Comment;
 
+import java.util.Optional;
+
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
+    Optional<Comment> findByIdAndIsDeletedFalse(Long id);
 }

--- a/src/main/java/server/loop/domain/post/service/CommentService.java
+++ b/src/main/java/server/loop/domain/post/service/CommentService.java
@@ -3,7 +3,6 @@ package server.loop.domain.post.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.loop.domain.post.dto.comment.req.CommentCreateRequestDto;
@@ -38,13 +37,16 @@ public class CommentService {
         log.info("[CreateComment] post={}, user={}", requestDto.getPostId(), email);
         User author = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        Post post = postRepository.findById(requestDto.getPostId())
+        Post post = postRepository.findByIdAndIsDeletedFalse(requestDto.getPostId())
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         Comment parentComment = null;
         if (requestDto.getParentId() != null) {
-            parentComment = commentRepository.findById(requestDto.getParentId())
+            parentComment = commentRepository.findByIdAndIsDeletedFalse(requestDto.getParentId())
                     .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND, "존재하지 않는 부모 댓글입니다."));
+            if (!parentComment.getPost().getId().equals(post.getId())) {
+                throw new CustomException(ErrorCode.CONFLICT, "부모 댓글이 현재 게시글에 속하지 않습니다.");
+            }
         }
 
         Comment comment = Comment.builder()
@@ -89,7 +91,7 @@ public class CommentService {
     // 특정 게시글의 댓글 목록 조회 (계층 구조로 변환)
     @Transactional(readOnly = true)
     public List<CommentResponseDto> getCommentsByPost(Long postId) {
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         return commentRepository.findAllByPost(post).stream()
@@ -100,7 +102,7 @@ public class CommentService {
     //댓글 수정
     public Long updateComment(Long commentId, CommentUpdateRequestDto requestDto, String email) {
         log.info("[UpdateComment] commentId={}, user={}", commentId, email);
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findByIdAndIsDeletedFalse(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
         if (!comment.getAuthor().getEmail().equals(email)) {
             throw new CustomException(ErrorCode.FORBIDDEN_USER, "댓글을 수정할 권한이 없습니다.");
@@ -113,7 +115,7 @@ public class CommentService {
     // 댓글 삭제
     public Long deleteComment(Long commentId, String email) {
         log.info("[DeleteComment] commentId={}, user={}", commentId, email);
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findByIdAndIsDeletedFalse(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
         if (!comment.getAuthor().getEmail().equals(email)) {
             throw new CustomException(ErrorCode.FORBIDDEN_USER, "댓글을 삭제할 권한이 없습니다.");

--- a/src/main/java/server/loop/domain/post/service/CommentService.java
+++ b/src/main/java/server/loop/domain/post/service/CommentService.java
@@ -16,6 +16,8 @@ import server.loop.domain.post.entity.repository.PostRepository;
 import server.loop.domain.post.event.CommentCreatedEvent;
 import server.loop.domain.user.entity.User;
 import server.loop.domain.user.entity.repository.UserRepository;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,14 +37,14 @@ public class CommentService {
     public Long createComment(CommentCreateRequestDto requestDto, String email) {
         log.info("[CreateComment] post={}, user={}", requestDto.getPostId(), email);
         User author = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Post post = postRepository.findById(requestDto.getPostId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         Comment parentComment = null;
         if (requestDto.getParentId() != null) {
             parentComment = commentRepository.findById(requestDto.getParentId())
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부모 댓글입니다."));
+                    .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND, "존재하지 않는 부모 댓글입니다."));
         }
 
         Comment comment = Comment.builder()
@@ -88,7 +90,7 @@ public class CommentService {
     @Transactional(readOnly = true)
     public List<CommentResponseDto> getCommentsByPost(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         return commentRepository.findAllByPost(post).stream()
                 .filter(comment -> comment.getParent() == null)
@@ -96,12 +98,12 @@ public class CommentService {
                 .collect(Collectors.toList());
     }
     //댓글 수정
-    public Long updateComment(Long commentId, CommentUpdateRequestDto requestDto, String email) throws AccessDeniedException {
+    public Long updateComment(Long commentId, CommentUpdateRequestDto requestDto, String email) {
         log.info("[UpdateComment] commentId={}, user={}", commentId, email);
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
         if (!comment.getAuthor().getEmail().equals(email)) {
-            throw new AccessDeniedException("댓글을 수정할 권한이 없습니다.");
+            throw new CustomException(ErrorCode.FORBIDDEN_USER, "댓글을 수정할 권한이 없습니다.");
         }
         comment.update(requestDto.getContent());
         return comment.getPost().getId();
@@ -109,12 +111,12 @@ public class CommentService {
 
 
     // 댓글 삭제
-    public Long deleteComment(Long commentId, String email) throws AccessDeniedException {
+    public Long deleteComment(Long commentId, String email) {
         log.info("[DeleteComment] commentId={}, user={}", commentId, email);
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
         if (!comment.getAuthor().getEmail().equals(email)) {
-            throw new AccessDeniedException("댓글을 삭제할 권한이 없습니다.");
+            throw new CustomException(ErrorCode.FORBIDDEN_USER, "댓글을 삭제할 권한이 없습니다.");
         }
         Long postId = comment.getPost().getId();
         comment.softDelete();

--- a/src/main/java/server/loop/domain/post/service/LikeService.java
+++ b/src/main/java/server/loop/domain/post/service/LikeService.java
@@ -13,6 +13,8 @@ import server.loop.domain.post.entity.repository.PostLikeRepository;
 import server.loop.domain.post.entity.repository.PostRepository;
 import server.loop.domain.user.entity.User;
 import server.loop.domain.user.entity.repository.UserRepository;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -32,9 +34,9 @@ public class LikeService {
 
     public PostLikeResponseDto toggleLike(Long postId, String email) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         // Optional을 활용하여 좋아요 존재 여부 확인
         Optional<PostLike> existingLike = postLikeRepository.findByUserAndPost(user, post);

--- a/src/main/java/server/loop/domain/post/service/LikeService.java
+++ b/src/main/java/server/loop/domain/post/service/LikeService.java
@@ -1,11 +1,9 @@
 package server.loop.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.loop.domain.post.dto.post.res.PostLikeResponseDto;
-import server.loop.domain.post.dto.post.res.PostResponseDto;
 import server.loop.domain.post.dto.post.res.TopLikedPostResponseDto;
 import server.loop.domain.post.entity.Post;
 import server.loop.domain.post.entity.PostLike;
@@ -35,7 +33,7 @@ public class LikeService {
     public PostLikeResponseDto toggleLike(Long postId, String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         // Optional을 활용하여 좋아요 존재 여부 확인

--- a/src/main/java/server/loop/domain/post/service/PostService.java
+++ b/src/main/java/server/loop/domain/post/service/PostService.java
@@ -93,7 +93,7 @@ public class PostService {
     @Transactional
     public List<String> updatePostInTransaction(Long postId, PostUpdateRequestDto requestDto,
                                                 List<String> newImageUrls, List<Long> deleteImageIds, String email) {
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         // 권한 체크 (간소화)
@@ -135,7 +135,7 @@ public class PostService {
     // 게시글 삭제
     @Transactional
     public List<String> deletePostInTransaction(Long postId, String email) {
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         if (!post.getAuthor().getEmail().equals(email)) {

--- a/src/main/java/server/loop/domain/post/service/PostService.java
+++ b/src/main/java/server/loop/domain/post/service/PostService.java
@@ -3,13 +3,10 @@ package server.loop.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 import server.loop.domain.post.dto.post.req.PostCreateRequestDto;
 import server.loop.domain.post.dto.post.req.PostUpdateRequestDto;
 import server.loop.domain.post.dto.post.res.PostDetailResponseDto;
@@ -23,13 +20,12 @@ import server.loop.domain.post.entity.repository.PostLikeRepository;
 import server.loop.domain.post.entity.repository.PostRepository;
 import server.loop.domain.user.entity.User;
 import server.loop.domain.user.entity.repository.UserRepository;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 import server.loop.global.config.s3.S3UploadService;
 
-import java.io.IOException;
-import java.nio.file.AccessDeniedException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -46,7 +42,7 @@ public class PostService {
     @Transactional
     public Long createPostInTransaction(PostCreateRequestDto requestDto, List<String> imageUrls, String email) {        log.info("[CreatePost] title={}, category={}, user={}", requestDto.getTitle(), requestDto.getCategory(), email);
         User author = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 1. 게시글의 텍스트 내용(제목, 본문 등)을 먼저 DB에 저장합니다.
         Post post = Post.builder()
@@ -72,7 +68,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public PostDetailResponseDto getPost(Long postId, User currentUser) {
         Post post = postRepository.findActivePostWithCommentsById(postId)
-                .orElseThrow(() -> new NoSuchElementException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
         boolean likedByUser = currentUser != null && post.isLikedBy(currentUser);
         return new PostDetailResponseDto(post, likedByUser);
     }
@@ -96,13 +92,13 @@ public class PostService {
     // 게시글 수정
     @Transactional
     public List<String> updatePostInTransaction(Long postId, PostUpdateRequestDto requestDto,
-                                                List<String> newImageUrls, List<Long> deleteImageIds, String email) throws AccessDeniedException {
+                                                List<String> newImageUrls, List<Long> deleteImageIds, String email) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         // 권한 체크 (간소화)
         if (!post.getAuthor().getEmail().equals(email)) {
-            throw new AccessDeniedException("게시글을 수정할 권한이 없습니다.");
+            throw new CustomException(ErrorCode.FORBIDDEN_USER, "게시글을 수정할 권한이 없습니다.");
         }
 
         // 텍스트 수정
@@ -138,12 +134,12 @@ public class PostService {
 
     // 게시글 삭제
     @Transactional
-    public List<String> deletePostInTransaction(Long postId, String email) throws AccessDeniedException {
+    public List<String> deletePostInTransaction(Long postId, String email) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         if (!post.getAuthor().getEmail().equals(email)) {
-            throw new AccessDeniedException("게시글을 삭제할 권한이 없습니다.");
+            throw new CustomException(ErrorCode.FORBIDDEN_USER, "게시글을 삭제할 권한이 없습니다.");
         }
 
         // 삭제 전 이미지 URL 백업

--- a/src/main/java/server/loop/domain/post/service/PostStateService.java
+++ b/src/main/java/server/loop/domain/post/service/PostStateService.java
@@ -16,7 +16,7 @@ public class PostStateService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public String checkAndBlindPost(Long postId) {
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
 
         if (post.getReportCount() >= REPORT_THRESHOLD) {

--- a/src/main/java/server/loop/domain/report/service/ReportService.java
+++ b/src/main/java/server/loop/domain/report/service/ReportService.java
@@ -28,7 +28,7 @@ public class ReportService {
     public String reportPost(Long postId, String email, String reason) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND, "존재하지 않거나 삭제된 게시글입니다."));
 
         if (reportRepository.existsByReporterAndTargetTypeAndTargetId(user, ReportTargetType.POST, postId)) {

--- a/src/main/java/server/loop/domain/user/controller/AdminController.java
+++ b/src/main/java/server/loop/domain/user/controller/AdminController.java
@@ -26,6 +26,8 @@ import server.loop.domain.user.entity.User;
 import server.loop.domain.user.entity.repository.UserRepository;
 import server.loop.domain.user.service.AdminService;
 import server.loop.global.common.PageResponse;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 
 @RestController
 @RequiredArgsConstructor
@@ -91,7 +93,7 @@ public class AdminController {
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         User admin = userRepository.findByEmail(userDetails.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("Admin not found"));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "Admin not found"));
         adminService.resolveReport(reportId, admin);
         return ResponseEntity.ok().build();
     }
@@ -116,7 +118,7 @@ public class AdminController {
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         User admin = userRepository.findByEmail(userDetails.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("Admin not found"));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "Admin not found"));
         adminService.rejectReport(reportId, admin);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/server/loop/domain/user/controller/UserController.java
+++ b/src/main/java/server/loop/domain/user/controller/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
 
     @Operation(summary = "회원가입", description = "이메일, 비밀번호, 닉네임 등으로 사용자를 생성합니다.")
     @PostMapping("/signup")
-    public ResponseEntity<Map<String, String>> signUp(@RequestBody UserSignUpDto userSignUpDto) throws Exception {
+    public ResponseEntity<Map<String, String>> signUp(@RequestBody UserSignUpDto userSignUpDto) {
         log.info("[SignUp] email={}, nickname={}", userSignUpDto.getEmail(), userSignUpDto.getNickname());
         userService.signUp(userSignUpDto);
         return ResponseEntity.ok(Map.of("message", "회원가입이 성공적으로 완료되었습니다."));
@@ -64,9 +64,7 @@ public class UserController {
     @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<UserResponseDto> getMyInfo(@AuthenticationPrincipal UserDetails userDetails) {
-        if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+        // userDetails가 null일 가능성은 SecurityConfig에서 이미 처리되므로, 여기서는 항상 유효하다고 가정
         UserResponseDto userInfo = userService.getUserInfoByEmail(userDetails.getUsername());
         return ResponseEntity.ok(userInfo);
     }
@@ -77,9 +75,7 @@ public class UserController {
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody PasswordUpdateRequestDto requestDto) {
 
-        if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+        // userDetails가 null일 가능성은 SecurityConfig에서 이미 처리되므로, 여기서는 항상 유효하다고 가정
         log.info("[UpdatePassword] user={}", userDetails.getUsername());
         userService.updatePassword(userDetails.getUsername(), requestDto);
         return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 변경되었습니다."));

--- a/src/main/java/server/loop/domain/user/entity/User.java
+++ b/src/main/java/server/loop/domain/user/entity/User.java
@@ -118,6 +118,9 @@ public class User extends BaseEntity {
     // 탈퇴 처리
     public void withdraw() {
         this.deletedAt = LocalDateTime.now();
+        this.status = UserStatus.WITHDRAWN;
+        this.suspendedUntil = null;
+        this.suspendedReason = null;
         this.email = null;
         this.password = null;
         this.nickname = "탈퇴한 회원(" + this.id + ")";

--- a/src/main/java/server/loop/domain/user/service/AdminService.java
+++ b/src/main/java/server/loop/domain/user/service/AdminService.java
@@ -17,6 +17,8 @@ import server.loop.domain.user.dto.res.AdminReportResponse;
 import server.loop.domain.user.entity.User;
 import server.loop.domain.user.entity.repository.UserRepository;
 import server.loop.global.common.PageResponse;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 
 @Service
 @RequiredArgsConstructor
@@ -43,55 +45,55 @@ public class AdminService {
 
     public void resolveReport(Long reportId, User admin) {
         Report report = reportRepository.findById(reportId)
-                .orElseThrow(() -> new IllegalArgumentException("Report not found: " + reportId));
+                .orElseThrow(() -> new CustomException(ErrorCode.UNKNOWN_SERVER_ERROR, "Report not found: " + reportId));
         report.resolve(admin);
     }
 
     //특정 신고를 '반려(REJECTED)' 상태로 변경
     public void rejectReport(Long reportId, User admin) {
         Report report = reportRepository.findById(reportId)
-                .orElseThrow(() -> new IllegalArgumentException("Report not found: " + reportId));
+                .orElseThrow(() -> new CustomException(ErrorCode.UNKNOWN_SERVER_ERROR, "Report not found: " + reportId));
         report.reject(admin);
     }
 
     //관리자 권한으로 특정 게시글을 삭제
     public void deletePost(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND, "Post not found: " + postId));
         post.softDelete();
     }
 
     //관리자 권한으로 특정 댓글을 논리적으로 삭제
     public void deleteComment(Long commentId) {
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("Comment not found: " + commentId));
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND, "Comment not found: " + commentId));
         comment.softDelete();
     }
 
     // 특정 사용자를 지정된 기간 동안 정지
     public void suspendUser(Long userId, int days, String reason) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "User not found: " + userId));
         user.suspend(days, reason);
     }
 
     //특정 사용자의 정지를 해제합니다.
     public void unsuspendUser(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "User not found: " + userId));
         user.unsuspend();
     }
 
     // 특정 사용자를 영구적으로 정지
     public void banUser(Long userId, String reason) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "User not found: " + userId));
         user.ban(reason);
     }
 
     public void grantAdminRole(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "User not found: " + userId));
         user.grantAdmin();
     }
 }

--- a/src/main/java/server/loop/domain/user/service/MyPageService.java
+++ b/src/main/java/server/loop/domain/user/service/MyPageService.java
@@ -13,6 +13,8 @@ import server.loop.domain.post.entity.repository.PostRepository;
 import server.loop.domain.user.dto.res.MyPagePostResponseDto;
 import server.loop.domain.user.entity.User;
 import server.loop.domain.user.entity.repository.UserRepository;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 
 @Service
 @Transactional(readOnly = true)
@@ -48,7 +50,7 @@ public class MyPageService {
     // 공통 로직: 사용자 이메일로 User 객체 찾기
     private User findUserByEmail(String email) {
         return userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
     // 공통 로직: Slice<Post>를 SliceResponseDto<MyPagePostResponseDto>로 변환

--- a/src/main/java/server/loop/domain/user/service/TermsService.java
+++ b/src/main/java/server/loop/domain/user/service/TermsService.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import server.loop.domain.user.dto.res.TermsResponseDto;
 import server.loop.domain.user.entity.TermsType;
 import server.loop.domain.user.entity.repository.TermsRepository;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 
 @Service
 @Transactional(readOnly = true)
@@ -17,7 +19,7 @@ public class TermsService {
     public TermsResponseDto getLatestTerms(TermsType type) {
         return termsRepository.findFirstByTypeOrderByVersionDesc(type)
                 .map(TermsResponseDto::from)
-                .orElseThrow(() -> new IllegalArgumentException(type + " 타입의 약관을 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.TERMS_NOT_FOUND, type + " 타입의 약관을 찾을 수 없습니다."));
 
     }
 }

--- a/src/main/java/server/loop/domain/user/service/UserService.java
+++ b/src/main/java/server/loop/domain/user/service/UserService.java
@@ -15,6 +15,8 @@ import server.loop.domain.user.dto.req.UserUpdateRequestDto;
 import server.loop.domain.user.dto.res.UserResponseDto;
 import server.loop.domain.user.entity.User;
 import server.loop.domain.user.entity.repository.UserRepository;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
 import server.loop.global.security.JwtTokenProvider;
 
 import java.time.LocalDateTime;
@@ -30,20 +32,20 @@ public class UserService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public Long signUp(UserSignUpDto signUpDto) throws Exception {
+    public Long signUp(UserSignUpDto signUpDto) {
         log.info("[SignUp] Request email: {}, nickname: {}", signUpDto.getEmail(), signUpDto.getNickname());
         // 이메일 중복 체크
         if (userRepository.findByEmail(signUpDto.getEmail()).isPresent()) {
             log.warn("[SignUp] Email already exists: {}", signUpDto.getEmail());
-            throw new Exception("이미 존재하는 이메일입니다.");
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
         //닉네임 중복 체크
         if (userRepository.findByNickname(signUpDto.getNickname()).isPresent()) {
             log.warn("[SignUp] Nickname already exists: {}", signUpDto.getNickname());
-            throw new Exception("이미 존재하는 닉네임입니다.");
+            throw new CustomException(ErrorCode.ALREADY_EXISTS, "이미 존재하는 닉네임입니다.");
         }
         if (!signUpDto.isAgreedToTermsOfService() || !signUpDto.isAgreedToPrivacyPolicy()) {
-            throw new IllegalArgumentException("필수 약관에 동의해야 합니다.");
+            throw new CustomException(ErrorCode.INVALID_BODY, "필수 약관에 동의해야 합니다.");
         }
         LocalDateTime now = LocalDateTime.now();
 
@@ -67,10 +69,10 @@ public class UserService {
     public TokenDto login(UserLoginDto loginDto) {
         log.info("[Login] Request email: {}", loginDto.getEmail());
         User user = userRepository.findByEmailAndDeletedAtIsNull(loginDto.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 올바르지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED_USER, "아이디 또는 비밀번호가 올바르지 않습니다."));
 
         if (!passwordEncoder.matches(loginDto.getPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("아이디 또는 비밀번호가 올바르지 않습니다.");
+            throw new CustomException(ErrorCode.UNAUTHORIZED_USER, "아이디 또는 비밀번호가 올바르지 않습니다.");
         }
 
         String accessToken = jwtTokenProvider.createAccessToken(user.getEmail());
@@ -91,7 +93,7 @@ public class UserService {
     @Transactional(readOnly = true) // 조회만 하므로 readOnly = true 추가
     public UserResponseDto getUserInfoByEmail(String email) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다.: " + email));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다.: " + email));
 
         // User 엔티티를 UserResponseDto로 변환하여 반환
         return new UserResponseDto(
@@ -102,12 +104,12 @@ public class UserService {
     }
 
     //회원 정보 수정
-    public void updateUser(UserUpdateRequestDto requestDto, String email) throws Exception {
+    public void updateUser(UserUpdateRequestDto requestDto, String email) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         if (requestDto.getNickname() != null && !requestDto.getNickname().isBlank()) {
             if (userRepository.findByNickname(requestDto.getNickname()).isPresent()) {
-                throw new Exception("이미 존재하는 닉네임입니다.");
+                throw new CustomException(ErrorCode.ALREADY_EXISTS, "이미 존재하는 닉네임입니다.");
             }
             user.updateNickname(requestDto.getNickname());
         }
@@ -119,7 +121,7 @@ public class UserService {
     //회원 탈퇴
     public void deleteUser(String email) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         refreshTokenRepository.deleteByUserId(user.getId());
 
@@ -130,20 +132,20 @@ public class UserService {
     //닉네임 변경
     public void updateNickname(String email, String newNickname) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "해당 사용자가 존재하지 않습니다."));
         if (newNickname == null || newNickname.isBlank()) {
-            throw new IllegalArgumentException("닉네임은 비어 있을 수 없습니다.");
+            throw new CustomException(ErrorCode.INVALID_NAME, "닉네임은 비어 있을 수 없습니다.");
         }
         user.setNickname(newNickname);
     }
     //비밀번호 변경
     public void updatePassword(String username, PasswordUpdateRequestDto dto) {
         User user = userRepository.findByEmail(username)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "해당 사용자가 존재하지 않습니다."));
 
         // 현재 비밀번호 일치 확인
         if (!passwordEncoder.matches(dto.getCurrentPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+            throw new CustomException(ErrorCode.INVALID_PASSWORD, "현재 비밀번호가 일치하지 않습니다.");
         }
 
         // 새 비밀번호 암호화 후 저장

--- a/src/main/java/server/loop/global/common/error/ErrorCode.java
+++ b/src/main/java/server/loop/global/common/error/ErrorCode.java
@@ -1,0 +1,72 @@
+package server.loop.global.common.error;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // 400 유효하지 않는 Request
+    INVALID_BODY("4000", "유효하지 않은 Body 형식입니다. :"),
+    INVALID_EMAIL("4001", "유효하지 않은 이메일 형식입니다."),
+    INVALID_PASSWORD("4002", "유효하지 않는 비밀번호 형식입니다."),
+    INVALID_NAME("4003", "유효하지 않는 이름 형식입니다."),
+    INVALID_SEARCH_KEYWORD("4004", "검색 키워드가 유효하지 않습니다."),
+
+    // 401 Unauthorized
+    UNAUTHORIZED_USER("4010", "로그인 정보가 틀렸습니다."),
+    INVALID_TOKEN("4011", "잘못된 토큰입니다."),
+
+    // 403 Forbidden
+    FORBIDDEN_USER("4030", "접근 권한이 없습니다."),
+    ALREADY_SCRAPPED("4031", "이미 스크랩 된 내용입니다."),
+
+    // 404 Not Found
+    POST_NOT_FOUND("4040", "해당 포스트를 찾을 수 없습니다."),
+    USER_NOT_FOUND("4041", "해당 유저를 찾을 수 없습니다. "),
+
+    // 405 Using wrong HTTP Method
+    WRONG_METHOD("4050", "허용되지 않은 메소드 입니다."),
+
+    // 409 Conflict
+    EMAIL_ALREADY_EXISTS("4090", "해당 이메일 사용자가 이미 존재합니다."),
+    CONFLICT("4091", "요청 충돌 발생"),
+    ALREADY_EXISTS("4092", "이미 존재합니다."),
+
+    // 500 Server
+    UNKNOWN_SERVER_ERROR("5000", "알 수 없는 서버 내부 오류입니다."),
+    UNKNOWN_DB_ERROR("5001", "JPA 오류가 발생하였습니다."),
+    INTERNAL_SERVER_ERROR("5002", "서버 내부 오류가 발생했습니다."),
+
+
+    // 502 - Bad Gateway
+
+    // 900 Request Body
+    NOT_NULL("9001", "필수값이 누락되었습니다."),
+    NOT_BLANK("9001", "필수값이 빈 값이거나 공백으로 되어있습니다."),
+    REGEX("9002", "형식에 맞지 않습니다. :"),
+    LENGTH("9003", "길이가 유효하지 않습니다. :"),
+
+    // S3 관련 오류
+    EMPTY_FILE_EXCEPTION("6000", "파일이 비어 있습니다."),
+    IO_EXCEPTION_ON_IMAGE_UPLOAD("6001", "이미지 업로드 중 IO 예외가 발생했습니다."),
+    NO_FILE_EXTENSION("6002", "파일에 확장자가 없습니다."),
+    INVALID_FILE_EXTENSION("6003", "지원하지 않는 파일 확장자입니다."),
+    PUT_OBJECT_EXCEPTION("6004", "S3 업로드(PutObject)에 실패했습니다."),
+    IO_EXCEPTION_ON_IMAGE_DELETE("6005", "이미지 삭제 중 IO 예외가 발생했습니다.");
+
+
+    private final String code;
+    private final String message;
+
+    public static ErrorCode resolveValidationErrorCode(String code) {
+        return switch (code) {
+            case "NotNull" -> NOT_NULL;
+            case "NotBlank" -> NOT_BLANK;
+            case "Pattern" -> REGEX;
+            case "Length" -> LENGTH;
+            default -> throw new IllegalArgumentException("Unexpected value: " + code);
+        };
+    }
+}

--- a/src/main/java/server/loop/global/common/error/ErrorCode.java
+++ b/src/main/java/server/loop/global/common/error/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     CHAT_ROOM_NOT_FOUND("4042", "해당 채팅방을 찾을 수 없습니다."),
     NOTIFICATION_NOT_FOUND("4043", "해당 알림을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND("4044", "해당 댓글을 찾을 수 없습니다."),
+    TERMS_NOT_FOUND("4045", "해당 타입의 약관을 찾을 수 없습니다."),
 
     // 405 Using wrong HTTP Method
     WRONG_METHOD("4050", "허용되지 않은 메소드 입니다."),

--- a/src/main/java/server/loop/global/common/error/ErrorCode.java
+++ b/src/main/java/server/loop/global/common/error/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     // 404 Not Found
     POST_NOT_FOUND("4040", "해당 포스트를 찾을 수 없습니다."),
     USER_NOT_FOUND("4041", "해당 유저를 찾을 수 없습니다. "),
+    CHAT_ROOM_NOT_FOUND("4042", "해당 채팅방을 찾을 수 없습니다."),
 
     // 405 Using wrong HTTP Method
     WRONG_METHOD("4050", "허용되지 않은 메소드 입니다."),

--- a/src/main/java/server/loop/global/common/error/ErrorCode.java
+++ b/src/main/java/server/loop/global/common/error/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     POST_NOT_FOUND("4040", "해당 포스트를 찾을 수 없습니다."),
     USER_NOT_FOUND("4041", "해당 유저를 찾을 수 없습니다. "),
     CHAT_ROOM_NOT_FOUND("4042", "해당 채팅방을 찾을 수 없습니다."),
+    NOTIFICATION_NOT_FOUND("4043", "해당 알림을 찾을 수 없습니다."),
 
     // 405 Using wrong HTTP Method
     WRONG_METHOD("4050", "허용되지 않은 메소드 입니다."),

--- a/src/main/java/server/loop/global/common/error/ErrorCode.java
+++ b/src/main/java/server/loop/global/common/error/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     USER_NOT_FOUND("4041", "해당 유저를 찾을 수 없습니다. "),
     CHAT_ROOM_NOT_FOUND("4042", "해당 채팅방을 찾을 수 없습니다."),
     NOTIFICATION_NOT_FOUND("4043", "해당 알림을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND("4044", "해당 댓글을 찾을 수 없습니다."),
 
     // 405 Using wrong HTTP Method
     WRONG_METHOD("4050", "허용되지 않은 메소드 입니다."),

--- a/src/main/java/server/loop/global/common/exception/ConflictException.java
+++ b/src/main/java/server/loop/global/common/exception/ConflictException.java
@@ -1,0 +1,14 @@
+package server.loop.global.common.exception;
+
+
+import capstone.mju.backend.domain.common.error.ErrorCode;
+
+public class ConflictException extends CustomException {
+
+    public ConflictException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+    public ConflictException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/server/loop/global/common/exception/ConflictException.java
+++ b/src/main/java/server/loop/global/common/exception/ConflictException.java
@@ -1,7 +1,7 @@
 package server.loop.global.common.exception;
 
 
-import capstone.mju.backend.domain.common.error.ErrorCode;
+import server.loop.global.common.error.ErrorCode;
 
 public class ConflictException extends CustomException {
 

--- a/src/main/java/server/loop/global/common/exception/CustomException.java
+++ b/src/main/java/server/loop/global/common/exception/CustomException.java
@@ -1,6 +1,6 @@
 package server.loop.global.common.exception;
 
-import capstone.mju.backend.domain.common.error.ErrorCode;
+import server.loop.global.common.error.ErrorCode;
 import lombok.Getter;
 @Getter
 public class CustomException extends RuntimeException{

--- a/src/main/java/server/loop/global/common/exception/CustomException.java
+++ b/src/main/java/server/loop/global/common/exception/CustomException.java
@@ -1,0 +1,18 @@
+package server.loop.global.common.exception;
+
+import capstone.mju.backend.domain.common.error.ErrorCode;
+import lombok.Getter;
+@Getter
+public class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+    private final String detail;
+
+    public CustomException(ErrorCode e){
+        this.detail = null;
+        this.errorCode = e;
+    }
+    public CustomException(ErrorCode e, String detail){
+        this.detail = detail;
+        this.errorCode = e;
+    }
+}

--- a/src/main/java/server/loop/global/common/exception/DtoValidationException.java
+++ b/src/main/java/server/loop/global/common/exception/DtoValidationException.java
@@ -1,7 +1,7 @@
 package server.loop.global.common.exception;
 
 
-import capstone.mju.backend.domain.common.error.ErrorCode;
+import server.loop.global.common.error.ErrorCode;
 
 public class DtoValidationException extends CustomException {
     public DtoValidationException(ErrorCode errorCode, String detail) {

--- a/src/main/java/server/loop/global/common/exception/DtoValidationException.java
+++ b/src/main/java/server/loop/global/common/exception/DtoValidationException.java
@@ -1,0 +1,10 @@
+package server.loop.global.common.exception;
+
+
+import capstone.mju.backend.domain.common.error.ErrorCode;
+
+public class DtoValidationException extends CustomException {
+    public DtoValidationException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/server/loop/global/common/exception/ForbiddenException.java
+++ b/src/main/java/server/loop/global/common/exception/ForbiddenException.java
@@ -1,0 +1,13 @@
+package server.loop.global.common.exception;
+
+
+import capstone.mju.backend.domain.common.error.ErrorCode;
+
+public class ForbiddenException extends CustomException {
+    public ForbiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+    public ForbiddenException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/server/loop/global/common/exception/ForbiddenException.java
+++ b/src/main/java/server/loop/global/common/exception/ForbiddenException.java
@@ -1,7 +1,7 @@
 package server.loop.global.common.exception;
 
 
-import capstone.mju.backend.domain.common.error.ErrorCode;
+import server.loop.global.common.error.ErrorCode;
 
 public class ForbiddenException extends CustomException {
     public ForbiddenException(ErrorCode errorCode) {

--- a/src/main/java/server/loop/global/common/exception/NotFoundException.java
+++ b/src/main/java/server/loop/global/common/exception/NotFoundException.java
@@ -1,7 +1,7 @@
 package server.loop.global.common.exception;
 
 
-import capstone.mju.backend.domain.common.error.ErrorCode;
+import server.loop.global.common.error.ErrorCode;
 
 public class NotFoundException extends CustomException {
     public NotFoundException(ErrorCode errorCode, String detail) {

--- a/src/main/java/server/loop/global/common/exception/NotFoundException.java
+++ b/src/main/java/server/loop/global/common/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package server.loop.global.common.exception;
+
+
+import capstone.mju.backend.domain.common.error.ErrorCode;
+
+public class NotFoundException extends CustomException {
+    public NotFoundException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}
+

--- a/src/main/java/server/loop/global/common/exception/UnauthorizedException.java
+++ b/src/main/java/server/loop/global/common/exception/UnauthorizedException.java
@@ -1,0 +1,15 @@
+package server.loop.global.common.exception;
+
+
+import capstone.mju.backend.domain.common.error.ErrorCode;
+
+public class UnauthorizedException extends CustomException {
+    public UnauthorizedException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+    public UnauthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}
+

--- a/src/main/java/server/loop/global/common/exception/UnauthorizedException.java
+++ b/src/main/java/server/loop/global/common/exception/UnauthorizedException.java
@@ -1,7 +1,7 @@
 package server.loop.global.common.exception;
 
 
-import capstone.mju.backend.domain.common.error.ErrorCode;
+import server.loop.global.common.error.ErrorCode;
 
 public class UnauthorizedException extends CustomException {
     public UnauthorizedException(ErrorCode errorCode, String detail) {

--- a/src/main/java/server/loop/global/common/exception/controller/ExceptionController.java
+++ b/src/main/java/server/loop/global/common/exception/controller/ExceptionController.java
@@ -1,9 +1,9 @@
 package server.loop.global.common.exception.controller;
 
-import capstone.mju.backend.domain.common.error.ErrorCode;
-import capstone.mju.backend.domain.common.exception.CustomException;
-import capstone.mju.backend.domain.common.exception.DtoValidationException;
-import capstone.mju.backend.domain.common.exception.dto.ErrorResponseDto;
+import server.loop.global.common.error.ErrorCode;
+import server.loop.global.common.exception.CustomException;
+import server.loop.global.common.exception.DtoValidationException;
+import server.loop.global.common.exception.dto.ErrorResponseDto;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/server/loop/global/common/exception/controller/ExceptionController.java
+++ b/src/main/java/server/loop/global/common/exception/controller/ExceptionController.java
@@ -1,0 +1,75 @@
+package server.loop.global.common.exception.controller;
+
+import capstone.mju.backend.domain.common.error.ErrorCode;
+import capstone.mju.backend.domain.common.exception.CustomException;
+import capstone.mju.backend.domain.common.exception.DtoValidationException;
+import capstone.mju.backend.domain.common.exception.dto.ErrorResponseDto;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ValidationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionController {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponseDto> handleCustomException(CustomException customException){
+        writeLog(customException);
+        HttpStatus httpStatus = this.resolveHttpStatus(customException);
+        return new ResponseEntity<>(ErrorResponseDto.res(customException), httpStatus);
+    }
+
+    @ExceptionHandler({ValidationException.class, MethodArgumentNotValidException.class})
+    public ResponseEntity<ErrorResponseDto> handleCustomException(MethodArgumentNotValidException methodArgumentNotValidException){
+        FieldError fieldError = methodArgumentNotValidException.getBindingResult().getFieldError();
+        if(fieldError == null){
+            return new ResponseEntity<>(ErrorResponseDto.res(String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                    methodArgumentNotValidException), HttpStatus.BAD_REQUEST);
+        }
+        ErrorCode validationErrorCode = ErrorCode.resolveValidationErrorCode(fieldError.getCode());
+        String detail = fieldError.getDefaultMessage();
+        DtoValidationException dtoValidationException = new DtoValidationException(validationErrorCode, detail);
+        this.writeLog(dtoValidationException);
+        return new ResponseEntity<>(ErrorResponseDto.res(dtoValidationException),HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleEntityNotFoundException(EntityNotFoundException entityNotFoundException){
+        writeLog(entityNotFoundException);
+        return new ResponseEntity<>(ErrorResponseDto.res(String.valueOf(HttpStatus.NOT_FOUND.value()),entityNotFoundException), HttpStatus.NOT_FOUND);
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleExceptioon(Exception exception){
+        this.writeLog(exception);
+        return new ResponseEntity<>(
+                ErrorResponseDto.res(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR.value()), exception),
+                HttpStatus.INTERNAL_SERVER_ERROR
+        );
+    }
+
+    private void writeLog(CustomException customException){
+        String exceptionName = customException.getClass().getSimpleName();
+        ErrorCode errorCode = customException.getErrorCode();
+        String detail = customException.getDetail();
+        log.error("[{}]{}:{}", exceptionName,errorCode.getMessage(), detail);
+    }
+
+    private void writeLog(Exception exception){
+        String exceptionName = exception.getClass().getSimpleName();
+        String message = exception.getMessage();
+        log.error("[{}]:{}", exceptionName, message);
+    }
+
+    private HttpStatus resolveHttpStatus(CustomException customException){
+        return HttpStatus.resolve(Integer.parseInt(customException.getErrorCode().getCode().substring(0,3)));
+    }
+}

--- a/src/main/java/server/loop/global/common/exception/dto/ErrorResponseDto.java
+++ b/src/main/java/server/loop/global/common/exception/dto/ErrorResponseDto.java
@@ -1,10 +1,10 @@
 package server.loop.global.common.exception.dto;
 
-import capstone.mju.backend.domain.common.exception.CustomException;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import server.loop.global.common.exception.CustomException;
 
 @AllArgsConstructor
 @Getter

--- a/src/main/java/server/loop/global/common/exception/dto/ErrorResponseDto.java
+++ b/src/main/java/server/loop/global/common/exception/dto/ErrorResponseDto.java
@@ -1,0 +1,33 @@
+package server.loop.global.common.exception.dto;
+
+import capstone.mju.backend.domain.common.exception.CustomException;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponseDto {
+    @JsonProperty("errorCode")
+    private final String errorCode;
+
+    @JsonProperty("message")
+    private final String message;
+
+    @JsonProperty("detail")
+    private final String detail;
+
+    public static ErrorResponseDto res(final CustomException customException){
+        String errorCode = customException.getErrorCode().getCode();
+        String message = customException.getErrorCode().getMessage();
+        String detail = customException.getDetail();
+        return new ErrorResponseDto(errorCode,message,detail);
+    }
+
+    public static ErrorResponseDto res(final String errorCode, final Exception e){
+        return new ErrorResponseDto(errorCode, e.getMessage(), null);
+    }
+
+}

--- a/src/main/java/server/loop/global/security/CustomUserDetailsService.java
+++ b/src/main/java/server/loop/global/security/CustomUserDetailsService.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import server.loop.domain.user.entity.User;
+import server.loop.domain.user.entity.UserStatus;
 import server.loop.domain.user.entity.repository.UserRepository;
 
 @Service
@@ -16,9 +17,17 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return userRepository.findByEmail(email)
+        return userRepository.findByEmailAndDeletedAtIsNull(email)
+                .map(this::validateActiveUser)
                 .map(this::createUserDetails)
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다."));
+    }
+
+    private User validateActiveUser(User user) {
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new UsernameNotFoundException("활성 상태의 유저가 아닙니다.");
+        }
+        return user;
     }
 
     private UserDetails createUserDetails(User user) {

--- a/src/main/java/server/loop/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/server/loop/global/security/oauth/OAuth2SuccessHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -13,6 +14,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import server.loop.domain.auth.entity.RefreshToken;
 import server.loop.domain.auth.entity.repo.RefreshTokenRepository;
 import server.loop.domain.user.entity.User;
+import server.loop.domain.user.entity.UserStatus;
 import server.loop.domain.user.entity.repository.UserRepository;
 import server.loop.global.security.JwtTokenProvider;
 
@@ -27,6 +29,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
+    @Value("${app.oauth2.redirect-uri:https://loop-front-eta.vercel.app/oauth/callback}")
+    private String frontendRedirectUri;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -37,9 +41,13 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // 유저 조회
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("User not found"));
+        if (user.getStatus() != UserStatus.ACTIVE || user.getDeletedAt() != null) {
+            log.warn("비활성 사용자 OAuth2 로그인 차단. email={}, status={}", user.getEmail(), user.getStatus());
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "활성 상태의 사용자만 로그인할 수 있습니다.");
+            return;
+        }
 
-        // 1. 토큰 생성 (인자 개수는 기존 JwtTokenProvider에 맞춰 수정하세요)
-        // 예: createAccessToken(email, role) 형태일 수도 있음
+        // 1. 토큰 생성
         String accessToken = jwtTokenProvider.createAccessToken(user.getEmail());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
 
@@ -49,19 +57,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .orElse(new RefreshToken(user, refreshToken));
         refreshTokenRepository.save(tokenEntity);
 
-        // 3. 프론트엔드로 리다이렉트
-        //로컬용
-//        String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:5173/oauth/callback")
-//                .queryParam("accessToken", accessToken)
-//                .queryParam("refreshToken", refreshToken)
-//                .build().toUriString();
-
-        String targetUrl = UriComponentsBuilder.fromUriString("https://loop-front-eta.vercel.app/oauth/callback")
-                .queryParam("accessToken", accessToken)
-                .queryParam("refreshToken", refreshToken)
+        // 3. 프론트엔드 리다이렉트 (query string 대신 fragment에 토큰 전달)
+        String targetUrl = UriComponentsBuilder.fromUriString(frontendRedirectUri)
+                .fragment("accessToken=" + accessToken + "&refreshToken=" + refreshToken)
                 .build().toUriString();
 
-        log.info("소셜 로그인 성공! 리다이렉트: {}", targetUrl);
+        log.info("소셜 로그인 성공. redirectUri={}", frontendRedirectUri);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,3 +63,7 @@ springdoc:
     path: /swagger-ui.html
     tags-sorter: alpha
     operations-sorter: alpha
+
+app:
+  oauth2:
+    redirect-uri: ${OAUTH2_REDIRECT_URI:https://loop-front-eta.vercel.app/oauth/callback}


### PR DESCRIPTION
 ## Summary                                                                                                                                                            
  보안/권한/데이터 정합성 이슈를 해결했습니다.                                                                                                                          
  핵심은 (1) 예외 처리 안전화, (2) OAuth 토큰 노출 제거, (3) 정지/밴/탈퇴 계정 인증 차단, (4) soft delete 우회 경로 차단입니다.                                         
                                                                                                                                                                        
  ## Background                                                                                                                                                         
  코드 리뷰 과정에서 아래 문제가 확인되었습니다.                                                                                                                        
  - 비표준 ErrorCode(600x/900x) 처리 시 예외 응답 생성 중 2차 오류 가능
  - OAuth 로그인 성공 시 access/refresh 토큰이 URL query로 노출                                                                                                         
  - 정지/밴/탈퇴 계정이 인증 흐름에서 차단되지 않음                                                                                                                     
  - 삭제된 게시글/댓글이 일부 경로에서 다시 조작 가능                                                                                                                   

  ## Changes                                                                                                                                                            
  - Exception handling                                                                                                                                                  
    - `ExceptionController.resolveHttpStatus`에 안전한 fallback 추가                                                                                                    
    - 900x -> 400, 일부 600x(입력 성격) -> 400, 그 외 -> 500 처리
  - OAuth security                                                                                                                                                      
    - `OAuth2SuccessHandler`에서 토큰 전달을 query -> fragment로 변경                                                                                                   
    - 리다이렉트 URL 하드코딩 제거, `app.oauth2.redirect-uri` 설정화                                                                                                    
    - 토큰 포함 URL 로그 제거                                                                                                                                           
  - Auth hardening                                                                                                                                                      
    - `UserService.login`에 사용자 상태 검증 추가                                                                                                                       
    - `CustomUserDetailsService`를 active + not deleted 사용자만 로드하도록 변경                                                                                        
    - `JwtAuthenticationFilter`에서 비활성 사용자 로드 실패 시 context clear 처리
    - OAuth2 성공 시 비활성 사용자 403 차단                                                                                                                             
    - `User.withdraw()`에서 `status=WITHDRAWN`로 상태 일관성 강화                                                                                                       
  - Soft delete enforcement
    - `PostService`, `CommentService`, `LikeService`, `ReportService`, `ChatService`, `PostStateService`에서
      게시글/댓글 조회를 `findByIdAndIsDeletedFalse`로 변경                                                                                                             
    - `CommentRepository.findByIdAndIsDeletedFalse` 추가                                                                                                                
    - 대댓글 생성 시 부모 댓글의 게시글 일치 여부 검증 추가                                                                                                             
  - Docs                                                                                                                                                                
    - `REVIEW_FINDINGS.md` 추가
                                                                                                                                                                        
  ## Impact                                                                                                                                                             
  - 보안: OAuth 토큰 노출 위험 감소, 비활성 계정 접근 차단 강화                                                                                                         
  - 데이터 정합성: 삭제된 리소스 재조작 경로 차단
  - API 동작 변화:                                                                                                                                                      
    - OAuth 콜백 페이지는 `location.search` 대신 `location.hash`에서 토큰 파싱 필요                                                                                     
    - 비활성 계정 로그인/인증 시 차단 응답 증가(의도된 변경)                                                                                                            
                                                                                                                                                                        
  ## Notes                                                                                                                                                              
  - 테스트는 현재 환경 제약(Gradle wrapper 다운로드 네트워크 제한)으로 실행하지 못했습니다.                                                                             
  - 프론트 환경에서 `OAUTH2_REDIRECT_URI` 설정 및 fragment 파싱 로직 반영이 필요합니다.